### PR TITLE
Add an Emberigniter tutorial on Ember2.0-Rails5 with JSONAPI

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -831,3 +831,8 @@
   name: Matthew White
   twitter: mattw59
   github: mattw59
+- id: 207
+  name: Frank Treacy
+  twitter: frank06
+  github: frank06
+  site: http://emberigniter.com/about/

--- a/_data/tutorials.yml
+++ b/_data/tutorials.yml
@@ -1,4 +1,12 @@
 ---
+- title: 'Building a modern bridge between Ember 2.0 and Rails 5 with JSON API'
+  author_ids:
+  - 207
+  date: '2015-08-13'
+  date_created: '2015-04-14'
+  date_updated: '2015-08-13'
+  urls:
+  - http://emberigniter.com/modern-bridge-ember-and-rails-5-with-json-api/
 - title: 'Getting Started with Ember.js using Ember-CLI'
   author_ids:
   - 147


### PR DESCRIPTION
Added the following link in the Tutorials section:
http://emberigniter.com/modern-bridge-ember-and-rails-5-with-json-api/
