### PR TITLE
Add Ember.js Cookbook to list of books

### DIFF
--- a/_data/books.yml
+++ b/_data/books.yml
@@ -1,4 +1,10 @@
 ---
+- title: 'Ember.js Cookbook'
+  author_ids:
+  - 312 
+  publisher: Packt Publishing 
+  url: https://www.packtpub.com/web-development/emberjs-cookbook 
+  payment: true
 - title: 'Front-end revolution with Ember.js'
   author_ids:
   - 299

--- a/_data/people.yml
+++ b/_data/people.yml
@@ -1282,3 +1282,8 @@
 - name: Todd Jordan
   id: 311
   twitter: tddjordan
+- id: 312 
+  name: Erik Hanchett 
+  twitter: ErikCH 
+  github: ErikCH 
+  site: http://programwitherik.com/


### PR DESCRIPTION
I'd like to add the Ember.js Cookbook as a book in the list.
