### PR TITLE
Add build instructions for GoStatic

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,3 +4,9 @@ collections:
     output: true
 sass:
     sass_dir: _sass
+
+gostatic:
+  build:
+    command:
+    - apt-get install -y libffi-dev
+    - bundle exec jekyll build --trace --destination $SITE_DIR --config=_config.production.yml


### PR DESCRIPTION
The last build failed. Turns out an update of Jekyll requires building from source which necessitates the following build instructions on the GoStatic platform.
