### PR TITLE
Fix 404'ing link

### DIFF
--- a/_recipes/index.md
+++ b/_recipes/index.md
@@ -21,4 +21,4 @@ Here are all of the available recipes:
 </ol>
 {% endfor %}
 
-If you would like to see more recipes, take a look at the [Suggesting A Recipe](./contributing/suggesting_a_recipe.html) section.
+If you would like to see more recipes, take a look at the [Suggesting A Recipe](./recipes/contributing/suggesting_a_recipe.html) section.


### PR DESCRIPTION
Related: https://github.com/emberwatch/emberwatch/issues/284
Affected page: http://emberwatch.com/recipes

The recipe link in the page is correct (as it is automatically generated), but this other link at the end needs to be updated.